### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ export default class InstafeedComponent extends Component {
 
   render() {
     return (
-      {this.renderInstafeed()}
+      <div id='instafeed'>
+        {this.renderInstafeed()}
+      </div>
     )
   }
 }  


### PR DESCRIPTION
instafeed need an element with id `instafeed`. And react must have one root element, that's why we wrap it inside `div` element itself. Instead, we can create a `div` for wrapper, and place `div#instafeed` inside.

Btw, thanks for creating this library 👍 